### PR TITLE
Update CONSIDER_PRIVATE as Env Variable

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -17,4 +17,4 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           GIST_ID: ${{ secrets.GIST_ID }}
-          CONSIDER_PRIVATE: true
+          CONSIDER_PRIVATE: ${{ secrets.CONSIDER_PRIVATE }}


### PR DESCRIPTION
Used your repo as original repo is inactive. Just as a good practice, kept private repo as an Env Variable.